### PR TITLE
dev(ios): fix constraints for iPad

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -23,6 +23,7 @@
 **/doc/api/
 .dart_tool/
 .flutter-plugins
+.flutter-plugins-dependencies
 .packages
 .pub-cache/
 .pub/

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true

--- a/example/ios/Flutter/Flutter.podspec
+++ b/example/ios/Flutter/Flutter.podspec
@@ -1,0 +1,18 @@
+#
+# NOTE: This podspec is NOT to be published. It is only used as a local source!
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'Flutter'
+  s.version          = '1.0.0'
+  s.summary          = 'High-performance, high-fidelity mobile apps.'
+  s.description      = <<-DESC
+Flutter provides an easy and productive way to build and deploy high-performance mobile apps for Android and iOS.
+                       DESC
+  s.homepage         = 'https://flutter.io'
+  s.license          = { :type => 'MIT' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
+  s.ios.deployment_target = '8.0'
+  s.vendored_frameworks = 'Flutter.framework'
+end

--- a/example/ios/Flutter/flutter_export_environment.sh
+++ b/example/ios/Flutter/flutter_export_environment.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# This is a generated file; do not edit or check into version control.
+export "FLUTTER_ROOT=/Users/tianhaozhou/Documents/flutter"
+export "FLUTTER_APPLICATION_PATH=/Users/tianhaozhou/Desktop/proj/esys-flutter-share/example"
+export "FLUTTER_TARGET=/Users/tianhaozhou/Desktop/proj/esys-flutter-share/example/lib/main.dart"
+export "FLUTTER_BUILD_DIR=build"
+export "SYMROOT=${SOURCE_ROOT}/../build/ios"
+export "OTHER_LDFLAGS=$(inherited) -framework Flutter"
+export "FLUTTER_FRAMEWORK_DIR=/Users/tianhaozhou/Documents/flutter/bin/cache/artifacts/engine/ios"
+export "FLUTTER_BUILD_NAME=1.0.0"
+export "FLUTTER_BUILD_NUMBER=1"
+export "TRACK_WIDGET_CREATION=true"

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -10,11 +10,7 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		30CC177B0653FC1250DBBDDC /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BB236F61766429B48517DC1 /* Pods_Runner.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
-		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
-		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
-		9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -27,8 +23,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */,
-				9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -38,14 +32,15 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		39BB12E32B990AE266562F3D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
+		3D487BE3CE19EE9BDBA56EB5 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		943C5BEE9B4061A8857487F5 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
-		9740EEBA1CF902C7004384FC /* Flutter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flutter.framework; path = Flutter/Flutter.framework; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -59,8 +54,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */,
-				3B80C3941E831B6300D905FE /* App.framework in Frameworks */,
 				30CC177B0653FC1250DBBDDC /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -79,6 +72,9 @@
 		4204C137FD4F389FE8CF8C94 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				943C5BEE9B4061A8857487F5 /* Pods-Runner.debug.xcconfig */,
+				39BB12E32B990AE266562F3D /* Pods-Runner.release.xcconfig */,
+				3D487BE3CE19EE9BDBA56EB5 /* Pods-Runner.profile.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -86,9 +82,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
-				3B80C3931E831B6300D905FE /* App.framework */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
-				9740EEBA1CF902C7004384FC /* Flutter.framework */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
 				9740EEB31CF90195004384FC /* Generated.xcconfig */,
@@ -225,7 +219,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin";
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
 		53F69E7EBD03F2E7D52A5B83 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -233,20 +227,22 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
+				"${BUILT_PRODUCTS_DIR}/device_info/device_info.framework",
 				"${BUILT_PRODUCTS_DIR}/esys_flutter_share/esys_flutter_share.framework",
 				"${BUILT_PRODUCTS_DIR}/path_provider/path_provider.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/device_info.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/esys_flutter_share.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {

--- a/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-</dict>
-</plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:device_info/device_info.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -21,6 +22,11 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  Rect getSharePopoverLocation() {
+    return Rect.fromLTWH(MediaQuery.of(context).size.width - 100.0,
+        MediaQuery.of(context).size.height, 0.0, 0.0);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -63,10 +69,17 @@ class _MyHomePageState extends State<MyHomePage> {
             )));
   }
 
+  Future<bool> _isIpad() async {
+    final iosInfo = await DeviceInfoPlugin().iosInfo;
+    return iosInfo.name.toLowerCase().contains('ipad');
+  }
+
   Future<void> _shareText() async {
     try {
+      final bool isIpad = await _isIpad();
       Share.text('my text title',
-          'This is my text to share with other applications.', 'text/plain');
+          'This is my text to share with other applications.', 'text/plain',
+          sharePositionOrigin: isIpad ? getSharePopoverLocation() : null);
     } catch (e) {
       print('error: $e');
     }
@@ -74,10 +87,12 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _shareImage() async {
     try {
+      final bool isIpad = await _isIpad();
       final ByteData bytes = await rootBundle.load('assets/image1.png');
       await Share.file(
           'esys image', 'esys.png', bytes.buffer.asUint8List(), 'image/png',
-          text: 'My optional text.');
+          text: 'My optional text.',
+          sharePositionOrigin: isIpad ? getSharePopoverLocation() : null);
     } catch (e) {
       print('error: $e');
     }
@@ -85,6 +100,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _shareImages() async {
     try {
+      final bool isIpad = await _isIpad();
       final ByteData bytes1 = await rootBundle.load('assets/image1.png');
       final ByteData bytes2 = await rootBundle.load('assets/image2.png');
 
@@ -94,7 +110,8 @@ class _MyHomePageState extends State<MyHomePage> {
             'esys.png': bytes1.buffer.asUint8List(),
             'bluedan.png': bytes2.buffer.asUint8List(),
           },
-          'image/png');
+          'image/png',
+          sharePositionOrigin: isIpad ? getSharePopoverLocation() : null);
     } catch (e) {
       print('error: $e');
     }
@@ -102,9 +119,11 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _shareCSV() async {
     try {
+      final bool isIpad = await _isIpad();
       final ByteData bytes = await rootBundle.load('assets/addresses.csv');
       await Share.file(
-          'addresses', 'addresses.csv', bytes.buffer.asUint8List(), 'text/csv');
+          'addresses', 'addresses.csv', bytes.buffer.asUint8List(), 'text/csv',
+          sharePositionOrigin: isIpad ? getSharePopoverLocation() : null);
     } catch (e) {
       print('error: $e');
     }
@@ -112,6 +131,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _shareMixed() async {
     try {
+      final bool isIpad = await _isIpad();
       final ByteData bytes1 = await rootBundle.load('assets/image1.png');
       final ByteData bytes2 = await rootBundle.load('assets/image2.png');
       final ByteData bytes3 = await rootBundle.load('assets/addresses.csv');
@@ -124,7 +144,8 @@ class _MyHomePageState extends State<MyHomePage> {
             'addresses.csv': bytes3.buffer.asUint8List(),
           },
           '*/*',
-          text: 'My optional text.');
+          text: 'My optional text.',
+          sharePositionOrigin: isIpad ? getSharePopoverLocation() : null);
     } catch (e) {
       print('error: $e');
     }
@@ -132,11 +153,13 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _shareImageFromUrl() async {
     try {
+      final bool isIpad = await _isIpad();
       var request = await HttpClient().getUrl(Uri.parse(
           'https://shop.esys.eu/media/image/6f/8f/af/amlog_transport-berwachung.jpg'));
       var response = await request.close();
       Uint8List bytes = await consolidateHttpClientResponseBytes(response);
-      await Share.file('ESYS AMLOG', 'amlog.jpg', bytes, 'image/jpg');
+      await Share.file('ESYS AMLOG', 'amlog.jpg', bytes, 'image/jpg',
+          sharePositionOrigin: isIpad ? getSharePopoverLocation() : null);
     } catch (e) {
       print('error: $e');
     }
@@ -144,9 +167,11 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _shareSound() async {
     try {
+      final bool isIpad = await _isIpad();
       final ByteData bytes = await rootBundle.load('assets/cat.mp3');
       await Share.file(
-          'Sound', 'cat.mp3', bytes.buffer.asUint8List(), 'audio/*');
+          'Sound', 'cat.mp3', bytes.buffer.asUint8List(), 'audio/*',
+          sharePositionOrigin: isIpad ? getSharePopoverLocation() : null);
     } catch (e) {
       print('error: $e');
     }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
+  device_info: ^0.4.2+1
 
 dev_dependencies:
   flutter_test:

--- a/ios/Classes/SwiftEsysFlutterSharePlugin.swift
+++ b/ios/Classes/SwiftEsysFlutterSharePlugin.swift
@@ -20,6 +20,32 @@ public class SwiftEsysFlutterSharePlugin: NSObject, FlutterPlugin {
             self.files(arguments: call.arguments)
         }
     }
+
+    func argsContainRect(argsMap:NSDictionary) -> Bool {
+        if (argsMap.value(forKey: "originX") == nil ||
+            argsMap.value(forKey: "originY") == nil ||
+            argsMap.value(forKey: "originWidth") == nil ||
+            argsMap.value(forKey: "originHeight") == nil) {
+            return false;
+        }
+        return true;
+    }
+
+    func parseRectParam(strArg:String) -> CGFloat {
+        if let numArg = NumberFormatter().number(from: strArg) {
+            return CGFloat(truncating: numArg)
+        }
+        return 0
+    }
+
+    func getRectFromArgs(argsMap:NSDictionary) -> CGRect {
+        let originX:CGFloat = parseRectParam(strArg: argsMap.value(forKey: "originX") as! String)
+        let originY:CGFloat = parseRectParam(strArg: argsMap.value(forKey: "originY") as! String)
+        let originWidth:CGFloat = parseRectParam(strArg: argsMap.value(forKey: "originWidth") as! String)
+        let originHeight:CGFloat = parseRectParam(strArg: argsMap.value(forKey: "originHeight") as! String)
+        let originRect = CGRect(x: originX, y: originY, width: originWidth, height: originHeight);
+        return originRect;
+    }
     
     func text(arguments:Any?) -> Void {
         // prepare method channel args
@@ -34,6 +60,9 @@ public class SwiftEsysFlutterSharePlugin: NSObject, FlutterPlugin {
         // present the view controller
         let controller = UIApplication.shared.keyWindow!.rootViewController as! FlutterViewController
         activityViewController.popoverPresentationController?.sourceView = controller.view
+        if (argsMap != nil && self.argsContainRect(argsMap: argsMap)) {
+            activityViewController.popoverPresentationController?.sourceRect = self.getRectFromArgs(argsMap: argsMap)
+        }
         
         controller.show(activityViewController, sender: self)
     }
@@ -63,6 +92,9 @@ public class SwiftEsysFlutterSharePlugin: NSObject, FlutterPlugin {
         // present the view controller
         let controller = UIApplication.shared.keyWindow!.rootViewController as! FlutterViewController
         activityViewController.popoverPresentationController?.sourceView = controller.view
+        if (argsMap != nil && self.argsContainRect(argsMap: argsMap)) {
+            activityViewController.popoverPresentationController?.sourceRect = self.getRectFromArgs(argsMap: argsMap)
+        }
         
         controller.show(activityViewController, sender: self)
     }
@@ -95,6 +127,9 @@ public class SwiftEsysFlutterSharePlugin: NSObject, FlutterPlugin {
         // present the view controller
         let controller = UIApplication.shared.keyWindow!.rootViewController as! FlutterViewController
         activityViewController.popoverPresentationController?.sourceView = controller.view
+        if (argsMap != nil && self.argsContainRect(argsMap: argsMap)) {
+            activityViewController.popoverPresentationController?.sourceRect = self.getRectFromArgs(argsMap: argsMap)
+        }
         
         controller.show(activityViewController, sender: self)
     }

--- a/lib/esys_flutter_share.dart
+++ b/lib/esys_flutter_share.dart
@@ -2,25 +2,39 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:path_provider/path_provider.dart';
 
 class Share {
   static const MethodChannel _channel = const MethodChannel(
       'channel:github.com/orgs/esysberlin/esys-flutter-share');
 
+  static void maybeAddRectToArgs(
+      Rect sharePositionOrigin, Map<String, dynamic> args) {
+    if (sharePositionOrigin != null) {
+      args['originX'] = sharePositionOrigin.left.toString();
+      args['originY'] = sharePositionOrigin.top.toString();
+      args['originWidth'] = sharePositionOrigin.width.toString();
+      args['originHeight'] = sharePositionOrigin.height.toString();
+    }
+  }
+
   /// Sends a text to other apps.
-  static void text(String title, String text, String mimeType) {
+  static void text(String title, String text, String mimeType,
+      {Rect sharePositionOrigin}) {
     Map argsMap = <String, String>{
       'title': '$title',
       'text': '$text',
       'mimeType': '$mimeType'
     };
+    maybeAddRectToArgs(sharePositionOrigin, argsMap);
     _channel.invokeMethod('text', argsMap);
   }
 
   /// Sends a file to other apps.
   static Future<void> file(
-      String title, String name, List<int> bytes, String mimeType, {String text = ''}) async {
+      String title, String name, List<int> bytes, String mimeType,
+      {String text = '', Rect sharePositionOrigin}) async {
     Map argsMap = <String, String>{
       'title': '$title',
       'name': '$name',
@@ -32,12 +46,15 @@ class Share {
     final file = await new File('${tempDir.path}/$name').create();
     await file.writeAsBytes(bytes);
 
+    maybeAddRectToArgs(sharePositionOrigin, argsMap);
+
     _channel.invokeMethod('file', argsMap);
   }
 
   /// Sends multiple files to other apps.
   static Future<void> files(
-      String title, Map<String, List<int>> files, String mimeType, {String text = ''}) async {
+      String title, Map<String, List<int>> files, String mimeType,
+      {String text = '', Rect sharePositionOrigin}) async {
     Map argsMap = <String, dynamic>{
       'title': '$title',
       'names': files.entries.toList().map((x) => x.key).toList(),
@@ -51,6 +68,8 @@ class Share {
       final file = await new File('${tempDir.path}/${entry.key}').create();
       await file.writeAsBytes(entry.value);
     }
+
+    maybeAddRectToArgs(sharePositionOrigin, argsMap);
 
     _channel.invokeMethod('files', argsMap);
   }


### PR DESCRIPTION
iPad, unlike the iPhone, will not use the width of the screen as the width of the popover window for sharing.

Instead, it requires the user to provide a location for its popover to originate.

The plugin currently doesn't supply an iPad with any constraint which will cause it to fail silently on some devices and crash on others.

This change allows the user to pass in an optional Rect object from Flutter to specify where the popover should locate.